### PR TITLE
Partial fix for issue 16

### DIFF
--- a/.github/workflows/check_atom_release.yml
+++ b/.github/workflows/check_atom_release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       filter-projects:
-        description: For use in troubleshooting
+        description: For use in troubleshooting to filter projects
         required: false
         default: ''
         type: string
@@ -24,7 +24,9 @@ jobs:
           ver=$(npm view @appthreat/atom dist-tags.latest)
           current=$(cat atom_version.txt)
           if [ "$current" != "$ver" ]; then
-              echo "release=true" >> "$GITHUB_OUTPUT"
+              if gh pr list -l "slice update" | grep -vq "no pull requests"; then
+                echo "release=true" >> "$GITHUB_OUTPUT"
+              fi
           fi
 
   run_generate:


### PR DESCRIPTION
Closes #16 

Adds a check to see if there is already an open slice update pr before automatically generating updated slices.

This will not prevent unnecessary commits from occurring whenever the slice update workflow is run, but will at least avoid them when a slice update PR is just waiting to be approved.

If a PR actually needs to be updated, the Update slices workflow can still be triggered directly with the default inputs and it will update the PR.